### PR TITLE
Change PPA for php5.6 due to deprecation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ test:
   override:
     - bundle exec rake docker:test:_circleci_parallel:
         parallel: true
+        timeout: 1200
 
 deployment:
   hub:

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -36,7 +36,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php-pear
 
 # Configure PHP.
-ADD ./conf/php/30-overrides.ini /etc/php5.6/apache2/conf.d/30-overrides.ini
+ADD ./conf/php/30-overrides.ini /etc/php/5.6/apache2/conf.d/30-overrides.ini
 
 # Enable PHP modules.
 RUN php5enmod opcache

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -35,8 +35,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php5.6-soap \
   php-pear
 
-# Purge any PHP 7 libraries.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y purge php7.0-common
+# Installing php-pear causes php7.0-common to be installed which then clobbers
+# the php binary used for CLI. This symlink unclobbers it.
+RUN update-alternatives --set php /usr/bin/php5.6
 
 # Configure PHP.
 ADD ./conf/php/30-overrides.ini /etc/php/5.6/apache2/conf.d/30-overrides.ini

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -35,12 +35,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php5.6-soap \
   php-pear
 
+# Purge any PHP 7 libraries.
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y purge php7.0-common
+
 # Configure PHP.
 ADD ./conf/php/30-overrides.ini /etc/php/5.6/apache2/conf.d/30-overrides.ini
 ADD ./conf/php/30-overrides.ini /etc/php/5.6/cli/conf.d/30-overrides.ini
-
-## Set the PHP binary to 5.6 instead of 7.0.
-RUN ln -sfn /usr/bin/php5.6 /etc/alternatives/php
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -16,30 +16,27 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client
 
 # Configure Apache.
 COPY ./conf/apache2/httpd-vhosts.conf /etc/apache2/sites-available/000-default.conf
-RUN a2enmod vhost_alias
-RUN a2enmod rewrite
-RUN a2enmod ssl
-RUN a2enmod headers
+RUN a2enmod vhost_alias && a2enmod rewrite && a2enmod ssl && a2enmod headers
 
 ## Fix issue with SSLMutex.
 RUN mkdir -p /var/run/apache2
 
 # Install & configure PHP.
-RUN add-apt-repository ppa:ondrej/php5-5.6
+RUN add-apt-repository ppa:ondrej/php
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  php5 \
-  php5-gd \
-  php5-dev \
-  php5-curl \
-  php5-mcrypt \
-  php5-mysql \
-  php5-memcached \
+  php5.6 \
+  php5.6-gd \
+  php5.6-dev \
+  php5.6-curl \
+  php5.6-mcrypt \
+  php5.6-mysql \
+  php5.6-memcached \
   php-soap \
   php-pear
 
 # Configure PHP.
-ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
+ADD ./conf/php/30-overrides.ini /etc/php5.6/apache2/conf.d/30-overrides.ini
 
 # Enable PHP modules.
 RUN php5enmod opcache

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -32,14 +32,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php5.6-mcrypt \
   php5.6-mysql \
   php5.6-memcached \
-  php-soap \
+  php5.6-soap
   php-pear
 
 # Configure PHP.
 ADD ./conf/php/30-overrides.ini /etc/php/5.6/apache2/conf.d/30-overrides.ini
+ADD ./conf/php/30-overrides.ini /etc/php/5.6/cli/conf.d/30-overrides.ini
 
-# Enable PHP modules.
-RUN php5enmod opcache
+## Set the PHP binary to 5.6 instead of 7.0.
+RUN ln -sfn /usr/bin/php5.6 /etc/alternatives/php
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -32,7 +32,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php5.6-mcrypt \
   php5.6-mysql \
   php5.6-memcached \
-  php5.6-soap
+  php5.6-soap \
   php-pear
 
 # Configure PHP.

--- a/soe/php5.6/Dockerfile
+++ b/soe/php5.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chinthaka Godawita <chin@sitback.com.au>
 
 # Install all packages.
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install socat ssmtp php5-xdebug
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install socat ssmtp php-xdebug
 
 # Configure socat.
 ADD ./conf/socat/start.sh /root/socat-start.sh

--- a/soe/php5.6/Dockerfile
+++ b/soe/php5.6/Dockerfile
@@ -19,10 +19,10 @@ COPY ./conf/apache2/ssl-vhost.conf /etc/apache2/sites-available/ssl.conf
 RUN a2ensite ssl
 
 # Configure PHP.
-ADD ./conf/php/30-overrides.ini /etc/php5/apache2/conf.d/30-overrides.ini
+ADD ./conf/php/30-overrides.ini /etc/php5.6/apache2/conf.d/30-overrides.ini
 
 # Setup Xdebug.
-ADD ./conf/php/30-xdebug-conf.ini /etc/php5/apache2/conf.d/30-xdebug-conf.ini
+ADD ./conf/php/30-xdebug-conf.ini /etc/php5.6/apache2/conf.d/30-xdebug-conf.ini
 
 # Install PimpMyLog.
 RUN mkdir -p /server/pimpmylog && \

--- a/soe/php5.6/Dockerfile
+++ b/soe/php5.6/Dockerfile
@@ -19,10 +19,10 @@ COPY ./conf/apache2/ssl-vhost.conf /etc/apache2/sites-available/ssl.conf
 RUN a2ensite ssl
 
 # Configure PHP.
-ADD ./conf/php/30-overrides.ini /etc/php5.6/apache2/conf.d/30-overrides.ini
+ADD ./conf/php/30-overrides.ini /etc/php/5.6/apache2/conf.d/30-overrides.ini
 
 # Setup Xdebug.
-ADD ./conf/php/30-xdebug-conf.ini /etc/php5.6/apache2/conf.d/30-xdebug-conf.ini
+ADD ./conf/php/30-xdebug-conf.ini /etc/php/5.6/apache2/conf.d/30-xdebug-conf.ini
 
 # Install PimpMyLog.
 RUN mkdir -p /server/pimpmylog && \

--- a/spec/ci/php56_spec.rb
+++ b/spec/ci/php56_spec.rb
@@ -2,6 +2,25 @@ require 'spec_helper'
 
 describe 'PHP 5.6 CI' do
   include_context 'ci' do
+    let(:php_packages) { [
+      'apache2',
+      'php5.6',
+      'mysql-client',
+      'memcached',
+      'php5.6-gd',
+      'php5.6-dev',
+      'php5.6-curl',
+      'php5.6-mcrypt',
+      'php5.6-mysql',
+      'php-memcached',
+      'php5.6-soap',
+      'php-pear'
+    ] }
+    let(:soe_packages) { [
+      'socat',
+      'php-xdebug',
+      'ssmtp'
+    ] }
     let(:php_version) { '5.6' }
   end
 

--- a/spec/php/56_spec.rb
+++ b/spec/php/56_spec.rb
@@ -2,6 +2,20 @@ require 'spec_helper'
 
 describe 'PHP 5.6' do
   include_context 'php' do
+    let(:php_packages) { [
+      'apache2',
+      'php5.6',
+      'mysql-client',
+      'memcached',
+      'php5.6-gd',
+      'php5.6-dev',
+      'php5.6-curl',
+      'php5.6-mcrypt',
+      'php5.6-mysql',
+      'php-memcached',
+      'php5.6-soap',
+      'php-pear'
+    ] }
     let(:php_version) { '5.6' }
   end
 

--- a/spec/soe/php56_spec.rb
+++ b/spec/soe/php56_spec.rb
@@ -2,6 +2,25 @@ require 'spec_helper'
 
 describe 'PHP 5.6 SOE' do
   include_context 'soe' do
+    let(:php_packages) { [
+      'apache2',
+      'php5.6',
+      'mysql-client',
+      'memcached',
+      'php5.6-gd',
+      'php5.6-dev',
+      'php5.6-curl',
+      'php5.6-mcrypt',
+      'php5.6-mysql',
+      'php-memcached',
+      'php5.6-soap',
+      'php-pear'
+    ] }
+    let(:soe_packages) { [
+      'socat',
+      'php-xdebug',
+      'ssmtp'
+    ] }
     let(:php_version) { '5.6' }
   end
 


### PR DESCRIPTION
https://launchpad.net/~ondrej/+archive/ubuntu/php5-5.6 is now deprecated, we need to swap to use https://launchpad.net/~ondrej/+archive/ubuntu/php/

Some details here: http://askubuntu.com/questions/773692/14-04-cleanly-upgrade-to-ppaondrej-php-from-ppaondrej-php5-5-6