### PR TITLE
Force dist-upgrade to run because of PHP update required

### DIFF
--- a/base/ubuntu-12.04/Dockerfile
+++ b/base/ubuntu-12.04/Dockerfile
@@ -3,7 +3,7 @@ FROM chinthakagodawita/ubuntu:12.04
 MAINTAINER Chinthaka Godawita <chin@sitback.com.au>
 
 # Increment this to trigger a full rebuild.
-ENV DC_BASE_VERSION 'ubuntu-12.04-3.0.3'
+ENV DC_BASE_VERSION 'ubuntu-12.04-3.0.4'
 
 # Update repositories and make sure we're on the latest 14.04 release.
 RUN apt-get -y update

--- a/base/ubuntu-14.04/Dockerfile
+++ b/base/ubuntu-14.04/Dockerfile
@@ -3,7 +3,7 @@ FROM chinthakagodawita/ubuntu:14.04
 MAINTAINER Chinthaka Godawita <chin@sitback.com.au>
 
 # Increment this to trigger a full rebuild.
-ENV DC_BASE_VERSION 'ubuntu-12.04-3.0.2'
+ENV DC_BASE_VERSION 'ubuntu-12.04-3.0.4'
 
 # Update repositories and make sure we're on the latest 14.04 release.
 RUN apt-get -y update


### PR DESCRIPTION
No local tests have been run as this just a version change used to trigger a base image rebuild.