### PR TITLE
Add the PHP5.6 XML extension

### DIFF
--- a/php/5.6/Dockerfile
+++ b/php/5.6/Dockerfile
@@ -33,6 +33,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php5.6-mysql \
   php5.6-memcached \
   php5.6-soap \
+  php5.6-xml \
   php-pear
 
 # Installing php-pear causes php7.0-common to be installed which then clobbers

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -26,6 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
   php7.0-dev \
   php7.0-curl \
   php7.0-mysql \
+  php7.0-xml \
   php-memcached \
   php-soap \
   php-pear


### PR DESCRIPTION
This fixes issues with `phpcs` not being able to load its config.