### PR TITLE
Fix issue with running Chrome under Ubuntu 16.04

### DIFF
--- a/node/ember/Dockerfile
+++ b/node/ember/Dockerfile
@@ -8,7 +8,10 @@ RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable 
 
 # Chrome + XVFB for headless browser support.
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb google-chrome-stable
+  DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb dbus-x11 google-chrome-stable
+
+# Add custom Chrome run script
+COPY ./conf/bin/google-chrome /usr/local/bin/google-chrome
 
 # Ember global requirements.
 RUN npm install -g bower ember-cli

--- a/node/ember/conf/bin/google-chrome
+++ b/node/ember/conf/bin/google-chrome
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Disable Chrome's sandboxer as it doesn't work under Docker.
+/usr/bin/google-chrome --no-sandbox

--- a/spec/node/ember_spec.rb
+++ b/spec/node/ember_spec.rb
@@ -49,7 +49,7 @@ describe 'Node.js Ember' do
 
   describe 'Working Google Chrome command' do
     describe command('which google-chrome') do
-      its(:stdout) { should match "/usr/bin/google-chrome" }
+      its(:stdout) { should match "/usr/local/bin/google-chrome" }
     end
   end
 


### PR DESCRIPTION
Added a custom Chrome run script that disables its new sandboxing mode.

This fixes an issue where it couldn't run with user namespacing disabled under a Ubuntu 16.04 Docker host.

See https://github.com/jessfraz/dockerfiles/issues/65 for more information.