### PR TITLE
Change base container for ember to be Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a set of Dockerfiles used to build all containers on [our container regi
     * 5.3.x (from base:ubuntu-16.04)
 * [node](https://hub.docker.com/r/sitback/node/)
     * base (6.x) (from base:ubuntu-16.04)
-    * ember (for testing) (from node:base)
+    * ember (for testing) (from base:ubuntu-14.04)
 * [elasticsearch](https://hub.docker.com/r/sitback/elasticsearch/)
     * 2.4.x (from elasticsearch:2.4, **for local development use only, do not use for production deployments!**)
 

--- a/node/ember/Dockerfile
+++ b/node/ember/Dockerfile
@@ -1,6 +1,18 @@
 # Container for running/testing EmberJS applications.
-FROM sitback/node:base
+FROM sitback/base:ubuntu-14.04
 MAINTAINER Chinthaka Godawita <chin@sitback.com.au>
+
+# Add node 6.x via nodesource.
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+
+# Add PM2 for process management.
+RUN npm install pm2 -g
+
+# Setup application base directory.
+RUN mkdir -p /server
+WORKDIR /server
+
 
 # Google's stable Chrome repos.
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/spec/node/ember_spec.rb
+++ b/spec/node/ember_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Node.js Ember' do
   include_context 'base' do
-    let(:ubuntu_version) { '16.04' }
+    let(:ubuntu_version) { '14.04' }
   end
 
   before(:all) do


### PR DESCRIPTION
This hopefully fixes all the issue we've had with running `xvfb-run` and Google Chrome.